### PR TITLE
Fix a bug in cmip_handler.py

### DIFF
--- a/lib/cmip_handler.py
+++ b/lib/cmip_handler.py
@@ -119,11 +119,12 @@ class CMIPHandler(object):
                 
                 # repeated usage in vtable will not be reloaded
                 if varname in self.ds:
+                    idf=idf+1
                     continue
                 
                 # CMIP6 regular
                 if not(self.model_name=='BCMM'):
-                    utils.write_log(print_prefix+'Loading '+self.fn_lst[idx])
+                    utils.write_log(print_prefix+'Loading '+self.fn_lst[idf])
                     ds=xr.open_dataset(self.fn_lst[idf])
                     idf=idf+1
                     


### PR DESCRIPTION
A bug occurs when repeated variables present in the mapping table, e.g., MPI-ESM1-2-HR_HIST.csv. 

The file iterator, idf, is not forwarded when the handler skips loading the first repeated variable. As the result, 'KeyError:' exception is thrown when it tries to load the next variable as the variable name and the input filename are inconsistent.

The scripts are very useful to the community so I think it would be best to get this tiny bug fixed here. 